### PR TITLE
Patch JMP to exit if 0x0000 is jumped to

### DIFF
--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -1856,6 +1856,12 @@ void JNZ(cpuState *state) {
 
 // 0xc3
 void JMP(cpuState *state) {
+
+    if(0x0000 == readShort(state->memory, state->PC + 1)){
+        printf("\nWBOOT addressed jumped to,\nQuitting...");
+        exit(EXIT_FAILURE);
+    }
+
     state->PC = readShort(state->memory, state->PC + 1);
 }
 


### PR DESCRIPTION
When the testing ROM detects an error it jumps to WBOOT (0x0000) which reruns the test. However, this causes an endless annoying loop. Patch JMP to exit instead of JMPing to 0x0000.