### PR TITLE
fix: heap-buffer-overflow in emulateState

### DIFF
--- a/src/handleState.c
+++ b/src/handleState.c
@@ -11,7 +11,7 @@ struct cpuState initState(void) {
     // This has the benefit of nulling pointers as well
     cpuState state = {0};
 
-    state.memory = calloc(UINT16_MAX, sizeof(uint8_t));
+    state.memory = calloc(UINT16_MAX, sizeof(uint16_t));
 
     if (NULL == state.memory) {
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Fix on line 14 in handleState fixes the following heap-buffer-overflow bug.
```
=================================================================
==2488436==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6310000107ff at pc 0x562032047bcc bp 0x7ffd070ae870 sp 0x7ffd070ae860
READ of size 1 at 0x6310000107ff thread T0
    #0 0x562032047bcb in emulateState /home/scott/8080emu/src/handleState.c:79
    #1 0x5620320476ff in main /home/scott/8080emu/src/main.c:36
    #2 0x7fc0414600b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
    #3 0x56203204732d in _start (/home/scott/8080emu/build/8080EMU+0x132d)

0x6310000107ff is located 0 bytes to the right of 65535-byte region [0x631000000800,0x6310000107ff)
allocated by thread T0 here:
    #0 0x7fc0416de6f7 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x562032047937 in initState /home/scott/8080emu/src/handleState.c:14
    #2 0x5620320474f5 in main /home/scott/8080emu/src/main.c:13
    #3 0x7fc0414600b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/scott/8080emu/src/handleState.c:79 in emulateState
```